### PR TITLE
fix : Add height property to #sentence selector

### DIFF
--- a/style.css
+++ b/style.css
@@ -73,6 +73,7 @@ p {
 }*/
 
 #sentence {
+  height: calc(100vh - 120px);
   margin: 0;
   padding: 50px 30px 70px;
   z-index: 100;


### PR DESCRIPTION
# What
- Added `height` property to `#sentence` selector in order to render the page layout optimizely
- Set that value with `calc(100vh - 120px)`  ( 120px is total vertical padding of `#sentence` ) 

# Why
to FIX broken layout when browsing with Full Screen mode

#### before fix
<img width="1440" alt="2018-08-07 23 31 42" src="https://user-images.githubusercontent.com/32263803/43783387-9a689c94-9a9c-11e8-8e9c-1401c945ec04.png">

#### after this commit
<img width="1440" alt="2018-08-07 23 49 24" src="https://user-images.githubusercontent.com/32263803/43783439-b33ff320-9a9c-11e8-9450-a7ea625f0ee0.png">
